### PR TITLE
Update Mailer.java

### DIFF
--- a/framework/src/play/mvc/Mailer.java
+++ b/framework/src/play/mvc/Mailer.java
@@ -579,7 +579,12 @@ public class Mailer implements LocalVariablesSupport {
             List<String> ccsList = (List<String>) infos.get().get("ccs");
             if (ccsList != null) {
                 for (String cc : ccsList) {
-                    email.addCc(cc);
+                    try {
+                        InternetAddress iAddress = new InternetAddress(cc);
+                        email.addCc(iAddress.getAddress(), iAddress.getPersonal());
+                    } catch (Exception e) {
+                        email.addCc(cc);
+                    }
                 }
             }
 


### PR DESCRIPTION
fix cc mailaddress display name Garbled on multibyte character


## Fixes


## Purpose

mailaddress display name Garbled on multibyte character

## Background Context

same bcc list approach?

